### PR TITLE
[FIX] Fixes invisible toolbar on all view types

### DIFF
--- a/debug_data_details/static/src/js/debug_items.js
+++ b/debug_data_details/static/src/js/debug_items.js
@@ -73,6 +73,7 @@ patch(viewService, "debug_data_details_viewService", {
                 action_id: options.actionId || false,
                 load_filters: options.loadIrFilters || false,
                 open_all_data: flag,
+                toolbar: options.loadActionMenus || true
             };
             if (env.isSmall) {
                 loadViewsOptions.mobile = true;


### PR DESCRIPTION
Action toolbars disappear when modules are installed. This occurs because we don't pass the toolbar option to the get_views function in the Odoo base. With this fix, we can see the action button in the desired views.